### PR TITLE
Slapd indexes

### DIFF
--- a/overlay/usr/lib/inithooks/bin/openldap-reinit.sh
+++ b/overlay/usr/lib/inithooks/bin/openldap-reinit.sh
@@ -88,21 +88,46 @@ add: olcTLSVerifyClient
 olcTLSVerifyClient: never
 EOL
 
+# configure Database Indices
 ldapmodify -Y EXTERNAL -H ldapi:/// <<EOL
 dn: olcDatabase={1}hdb,cn=config
 add: olcDbIndex
 olcDbIndex: cn eq,pres,sub
+-
+add: olcDbIndex
 olcDbIndex: sn eq,pres,sub
+-
+add: olcDbIndex
 olcDbIndex: ou eq,pres,sub
+-
+add: olcDbIndex
 olcDbIndex: uid eq,pres,sub
+-
+add: olcDbIndex
 olcDbIndex: displayName eq,pres,sub
+-
+add: olcDbIndex
 olcDbIndex: mail,givenName eq,subinitial
+-
+add: olcDbIndex
 olcDbIndex: uidNumber eq
+-
+add: olcDbIndex
 olcDbIndex: gidNumber eq
+-
+add: olcDbIndex
 olcDbIndex: loginShell eq
+-
+add: olcDbIndex
 olcDbIndex: memberUid eq,pres,sub
+-
+add: olcDbIndex
 olcDbIndex: uniqueMember eq,pres
+-
+add: olcDbIndex
 olcDbIndex: dc eq
+-
+add: olcDbIndex
 olcDbIndex: default sub
 EOL
 


### PR DESCRIPTION
In the process of setting up the openLDAP appliance to match my current configuration with centOS I found that I had several ldap attributes indexed that are recommended in the openLDAP documentation as good defaults. Since I also wanted to get my hands dirty with tkldev I went ahead and added them as part of the inithooks script.
