### PR TITLE
Fix Build Issues in Jessie

### DIFF
--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -5,8 +5,8 @@ dl() {
     cd $2; curl -L -f -O $PROXY $1; cd -
 }
 
-VERSION="1.2.3/phpldapadmin-1.2.3.tgz"
-URL="http://sourceforge.net/projects/phpldapadmin/files/phpldapadmin-php5/$VERSION"
+VERSION="master.tar.gz"
+URL="https://github.com/leenooks/phpLDAPadmin/archive/$VERSION"
 
 dl $URL /usr/local/src
 

--- a/conf.d/main
+++ b/conf.d/main
@@ -7,9 +7,9 @@ SRC=/usr/local/src
 WEBROOT=/var/www/phpldapadmin
 
 # phpldapadmin: unpack
-tar -zxf $SRC/phpldapadmin-*.tgz -C $(dirname $WEBROOT)
-rm $SRC/phpldapadmin-*.tgz
-mv $(dirname $WEBROOT)/phpldapadmin-* $WEBROOT
+tar -zxf $SRC/master.tar.gz -C $(dirname $WEBROOT)
+rm $SRC/master.tar.gz
+mv $(dirname $WEBROOT)/phpLDAPadmin-* $WEBROOT
 
 # phpldapadmin: create base configuration
 cat >$WEBROOT/config/config.php<<EOF

--- a/overlay/usr/lib/inithooks/bin/openldap-reinit.sh
+++ b/overlay/usr/lib/inithooks/bin/openldap-reinit.sh
@@ -92,6 +92,12 @@ EOL
 # configure Database Indices
 ldapmodify -Y EXTERNAL -H ldapi:/// <<EOL
 dn: olcDatabase={1}hdb,cn=config
+delete: olcDbIndex
+olcDbIndex: cn,uid eq
+-
+delete: olcDbIndex
+olcDbIndex: member,memberUid eq
+-
 add: olcDbIndex
 olcDbIndex: cn eq,pres,sub
 -
@@ -111,16 +117,13 @@ add: olcDbIndex
 olcDbIndex: mail,givenName eq,subinitial
 -
 add: olcDbIndex
-olcDbIndex: uidNumber eq
--
-add: olcDbIndex
-olcDbIndex: gidNumber eq
--
-add: olcDbIndex
 olcDbIndex: loginShell eq
 -
 add: olcDbIndex
 olcDbIndex: memberUid eq,pres,sub
+-
+add: olcDbIndex
+olcDbIndex: member eq,pres
 -
 add: olcDbIndex
 olcDbIndex: uniqueMember eq,pres


### PR DESCRIPTION
The first commit, 86ba54cc6b981ae3ae4dbcc6335d95d6ca401b89, fixes the build issues that @JedMeister was having in issue #418.

The second commit, 695deb7ec8615b2685dda32842d91cfaf214771b, fixes the error when trying to use phpLDAPadmin in Jessie since the PHP version is > 5.5. I just grabbed the latest commit from the phpLDAPadmin repo since there wasn't a tagged release with the fixes to download. If it needs to download a specific commit, let me know and I can update it, or you can update it too.