### PR TITLE
Fix download

### DIFF
--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -9,4 +9,6 @@ USER_REPO="leenooks/phpLDAPadmin"
 VERSION=$(gh_releases ${USER_REPO} | sort -V | tail -1)
 URL="https://github.com/${USER_REPO}/archive/${VERSION}.tar.gz"
 
-dl $URL /usr/local/src
+SRC=/usr/local/src
+dl $URL $SRC
+mv $SRC/$VERSION.tar.gz $SRC/phpldapadmin.tar.gz

--- a/conf.d/main
+++ b/conf.d/main
@@ -7,8 +7,8 @@ SRC=/usr/local/src
 WEBROOT=/var/www/phpldapadmin
 
 # phpldapadmin: unpack
-tar -zxf $SRC/master.tar.gz -C $(dirname $WEBROOT)
-rm $SRC/master.tar.gz
+tar -zxf $SRC/phpldapadmin.tar.gz -C $(dirname $WEBROOT)
+rm $SRC/phpldapadmin.tar.gz
 mv $(dirname $WEBROOT)/phpLDAPadmin-* $WEBROOT
 
 # copy custom templates into phpldapadmin directory
@@ -71,7 +71,7 @@ sed -i "s|^SLAPD_SERVICES.*|SLAPD_SERVICES=\"ldap:/// ldapi:/// ldaps:///\"|" $C
 service slapd start
 
 # generate TLS certs and re-initialize ldap
-/usr/lib/inithooks/firstboot.d/20regen-openldap-secrets
+turnkey-regen-ldap-certs $LDAP_DOMAIN
 /usr/lib/inithooks/bin/openldap.py --domain=$LDAP_DOMAIN --pass=$LDAP_PASS
 
 service slapd stop

--- a/overlay/usr/local/bin/turnkey-regen-ldap-certs
+++ b/overlay/usr/local/bin/turnkey-regen-ldap-certs
@@ -27,7 +27,7 @@ Usage: $(basename $0) fqdn|ip [-f|--force]
     hostname mismatch between the URI and the certificate).
 
     Success will be noted by exit with a zero exit code. Exit code 1 signifies
-    a failure and should be accompaied with a message.
+    a failure and should be accompanied with a message.
 
 Arguments::
 


### PR DESCRIPTION
Last minute fixes for v16.1.

- fix the phpLDAPadmin download filename.
- call `turnkey-regen-ldap-certs` directly (previously was calling inithook).
- fix a typo

@OnGle 